### PR TITLE
Merge source sharing same location

### DIFF
--- a/polyskel.py
+++ b/polyskel.py
@@ -446,7 +446,27 @@ class _EventQueue:
 		for item in self.__data:
 			print(item)
 
+def merge_sources(skeleton):
+    """ Multiple sources may share same location 
+    :param skeleton:
+    :return:
+    """
+    sources = {}
+    to_remove = []
+    for i, p in enumerate(skeleton):
+        if p.source in sources:
+            source = sources[p.source]
+            # source exists, merge sinks
+            for sink in p.sinks:
+                if sink not in skeleton[source].sinks:
+                    skeleton[source].sinks.append(sink)
+            to_remove.append(i)
+        else:
+            sources[p.source] = i
+    for i in reversed(to_remove):
+        skeleton.pop(i)
 
+			
 def skeletonize(polygon, holes=None):
 	"""
 	Compute the straight skeleton of a polygon.
@@ -488,4 +508,5 @@ def skeletonize(polygon, holes=None):
 				_debug.line((arc.source.x, arc.source.y, sink.x, sink.y), fill="red")
 
 			_debug.show()
+	merge_sources(output)
 	return output


### PR DESCRIPTION
On some degenerated cases ( U shaped roofs) result end up with 2 or more sources sharing same location.
This fix merge sinks of duplicated sources and remove "duplicated" sources.